### PR TITLE
Support additional arguments for DB import/export

### DIFF
--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -59,6 +59,9 @@ class ExportCommand extends ContainerAwareCommand
         $parameters[] = sprintf('--password=%s', escapeshellarg($dbParams['dbPass']));
         $parameters[] = sprintf('--host=%s', escapeshellarg($dbParams['dbHost']));
 
+        if ($dbParams['databaseExportArguments'] !== '') {
+            $parameters[] = implode(' ', array_map('escapeshellarg', explode(' ', $dbParams['databaseExportArguments'])));
+        }
 
         // Write to file instead of stdout
         $toFile = $input->getOption(self::OPT_FILE);

--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -59,7 +59,7 @@ class ExportCommand extends ContainerAwareCommand
         $parameters[] = sprintf('--password=%s', escapeshellarg($dbParams['dbPass']));
         $parameters[] = sprintf('--host=%s', escapeshellarg($dbParams['dbHost']));
 
-        if ($dbParams['databaseExportArguments'] !== '') {
+        if (!empty($dbParams['databaseExportArguments'])) {
             $parameters[] = implode(' ', array_map('escapeshellarg', explode(' ', $dbParams['databaseExportArguments'])));
         }
 

--- a/Command/FetchCommand.php
+++ b/Command/FetchCommand.php
@@ -216,9 +216,9 @@ class FetchCommand extends AbstractCommand
         $dbParams = $this->getDatabaseParameter();
 
         // Import Dump
-        $databaseImportArguments = $dbParams['databaseImportArguments'];
-        if ($databaseImportArguments !== '') {
-            $databaseImportArguments = implode(' ', array_map('escapeshellarg', explode(' ', $databaseImportArguments)));
+        $databaseImportArguments = '';
+        if (!empty($dbParams['databaseImportArguments'])) {
+                $databaseImportArguments = implode(' ', array_map('escapeshellarg', explode(' ', $dbParams['databaseImportArguments'])));
         }
         $importCmd = sprintf(
             'mysql %s --user=%s --password=%s --host=%s %s < %s 2>&1',

--- a/Command/FetchCommand.php
+++ b/Command/FetchCommand.php
@@ -216,12 +216,17 @@ class FetchCommand extends AbstractCommand
         $dbParams = $this->getDatabaseParameter();
 
         // Import Dump
+        $databaseImportArguments = $dbParams['databaseImportArguments'];
+        if ($databaseImportArguments !== '') {
+            $databaseImportArguments = implode(' ', array_map('escapeshellarg', explode(' ', $databaseImportArguments)));
+        }
         $importCmd = sprintf(
-            'mysql %s --user=%s --password=%s --host=%s < %s 2>&1',
+            'mysql %s --user=%s --password=%s --host=%s %s < %s 2>&1',
             escapeshellarg($dbParams['dbName']),
             escapeshellarg($dbParams['dbUser']),
             escapeshellarg($dbParams['dbPass']),
             escapeshellarg($dbParams['dbHost']),
+            $databaseImportArguments,
             escapeshellarg($tmpFile)
         );
         $this->progress();

--- a/Resources/config/parameters.yml
+++ b/Resources/config/parameters.yml
@@ -61,3 +61,9 @@ parameters:
 
     # Fetch Database via sql file, not via stdout. This scales better for large databases
     data_transfer_bundle.db_via_file: true
+
+    # Additional mysql arguments for DB import, e.g. '--compress'
+    data_transfer_bundle.database.import_arguments: ~
+
+    # Additional mysqldump arguments for DB export, e.g. '--disable-keys'
+    data_transfer_bundle.database.export_arguments: ~

--- a/Traits/DatabaseConnectionTrait.php
+++ b/Traits/DatabaseConnectionTrait.php
@@ -29,10 +29,19 @@ trait DatabaseConnectionTrait
     protected function getDatabaseParameter()
     {
         if($this->getContainer()->getParameter('data_transfer_bundle.siteaccess')) {
-            return $this->getEzPublishDatabase();
+            $parameters = $this->getEzPublishDatabase();
         } else {
-            return $this->getSymfonyDatabase();
+            $parameters = $this->getSymfonyDatabase();
         }
+
+        if ($this->getContainer()->hasParameter('data_transfer_bundle.database.import_arguments')) {
+            $parameters['databaseImportArguments'] = $this->getContainer()->getParameter('data_transfer_bundle.database.import_arguments');
+        }
+        if ($this->getContainer()->hasParameter('data_transfer_bundle.database.export_arguments')) {
+            $parameters['databaseExportArguments'] = $this->getContainer()->getParameter('data_transfer_bundle.database.export_arguments');
+        }
+
+        return $parameters;
     }
 
     /**


### PR DESCRIPTION
Added two new parameters:

`data_transfer_bundle.db.mysql_import_arguments`
to add arguments to the mysql command

`data_transfer_bundle.db.mysql_export_arguments`
to add arguments to the mysqldump command
